### PR TITLE
Check several files at a time with git ls-files.

### DIFF
--- a/pre-commit.d/20warn-problem-files
+++ b/pre-commit.d/20warn-problem-files
@@ -12,8 +12,8 @@ elif [ "$VCS" = hg ]; then
 	special=$(find . ! -type d ! -type f ! -type l | exclude_internal) || true
 	hardlinks=$(find . -type f ! -links 1 -exec hg status {} \; | exclude_internal ) || true
 elif [ "$VCS" = git ]; then
-	special=$(find . ! -type d ! -type f ! -type l -exec git ls-files --exclude-standard --cached --others {} \; | exclude_internal) || true
-	hardlinks=$(find . -type f ! -links 1 -exec git ls-files --exclude-standard --cached --others {} \; | exclude_internal) || true
+	special=$(find . ! -type d ! -type f ! -type l -exec git ls-files --exclude-standard --cached --others {} + | exclude_internal) || true
+	hardlinks=$(find . -type f ! -links 1 -exec git ls-files --exclude-standard --cached --others {} + | exclude_internal) || true
 else
 	special=""
 fi


### PR DESCRIPTION
Use the `+` feature of `find` to check multiple files at once with `git ls-files`.

This speeds up a hardlinks search with 65000 entries (multiple shared git repos inside /etc) from 2'30'' to about 2''.