### PR TITLE
portability: for non GNU systems

### DIFF
--- a/commit.d/50vcs-commit
+++ b/commit.d/50vcs-commit
@@ -36,7 +36,7 @@ else
 	# try to check tty ownership, in case user su'd to root
 	TTY="$(tty 2>/dev/null || true)"
 	if [ -n "$TTY" ] && [ -c "$TTY" ]; then
-		USER="$(find "$TTY" -printf "%u")"
+		USER="$(ls -ld $TTY | awk '{print $3}')"
 	fi
 fi
 

--- a/etckeeper.conf
+++ b/etckeeper.conf
@@ -24,17 +24,17 @@ DARCS_COMMIT_OPTIONS="-a"
 # (the option is enabled automatically by cronjob regardless).
 #AVOID_SPECIAL_FILE_WARNING=1
 
-# Uncomment to avoid etckeeper committing existing changes to 
+# Uncomment to avoid etckeeper committing existing changes to
 # /etc before installation. It will cancel the installation,
 # so you can commit the changes by hand.
 #AVOID_COMMIT_BEFORE_INSTALL=1
 
 # The high-level package manager that's being used.
-# (apt, pacman, pacman-g2, yum, dnf, zypper etc)
+# (apt, pacman, pacman-g2, yum, dnf, zypper, pkg, etc)
 HIGHLEVEL_PACKAGE_MANAGER=apt
 
 # The low-level package manager that's being used.
-# (dpkg, rpm, pacman, pacmatic, pacman-g2, etc)
+# (dpkg, rpm, pacman, pacmatic, pacman-g2, pkgng, etc)
 LOWLEVEL_PACKAGE_MANAGER=dpkg
 
 # To push each commit to a remote, put the name of the remote here.

--- a/pkgng/README
+++ b/pkgng/README
@@ -22,3 +22,6 @@ cd pkgng && make && make install
 
 # configure pkg to use the pkgng plugin, in /usr/local/etc/pkg.conf
 echo " PLUGINS [ etckeeper ]" >> /usr/local/etc/pkg.conf
+
+# initialize /etc with 'etckeeper init'
+etckeeper init

--- a/pkgng/README
+++ b/pkgng/README
@@ -6,8 +6,8 @@ pkg install git
 # install etckeeper and its pkgng plugin
 cd /usr/local && git clone https://github.com/joeyh/etckeeper
 
-# prepare etc
-mv /usr/local/etc /etc/local; ln -s /etc/local/etc /usr/local
+# prepare etc (this is needed until "track multiple directories" is resolved: http://etckeeper.branchable.com/todo/track_multiple_directories/)
+mkdir -p /etc/local; mv /usr/local/etc /etc/local; ln -s /etc/local/etc /usr/local
 
 # link script into path
 ln -s /usr/local/etckeeper/etckeeper /usr/local/bin/etckeeper

--- a/pkgng/README
+++ b/pkgng/README
@@ -1,8 +1,24 @@
-To use on FreeBSD, install etckeeper manually and install the plugin
-with:
- $ cd pkgng
- $ make
- $ make install
+Instructions for FreeBSD (most of them you need to run as root):
 
-and add this line to /usr/local/etc/pkg.conf:
- PLUGINS [ etckeeper ]
+# install git
+pkg install git
+
+# install etckeeper and its pkgng plugin
+cd /usr/local && git clone https://github.com/joeyh/etckeeper
+
+# prepare etc
+mv /usr/local/etc /etc/local; ln -s /etc/local/etc /usr/local
+
+# link script into path
+ln -s /usr/local/etckeeper/etckeeper /usr/local/bin/etckeeper
+
+# symlink etckeeper dir into /etc
+ln -s /usr/local/etckeeper/ /etc
+
+# set HIGHLEVEL_PACKAGE_MANAGER=pkg in /etc/etckeeper/etckeeper.conf
+
+# build pkgng plugin
+cd pkgng && make && make install
+
+# configure pkg to use the pkgng plugin, in /usr/local/etc/pkg.conf
+echo " PLUGINS [ etckeeper ]" >> /usr/local/etc/pkg.conf

--- a/pkgng/README
+++ b/pkgng/README
@@ -15,7 +15,9 @@ ln -s /usr/local/etckeeper/etckeeper /usr/local/bin/etckeeper
 # symlink etckeeper dir into /etc
 ln -s /usr/local/etckeeper/ /etc
 
-# set HIGHLEVEL_PACKAGE_MANAGER=pkg in /etc/etckeeper/etckeeper.conf
+# Configure pkg & pkgng in /etc/etckeeper/etckeeper.conf:
+# HIGHLEVEL_PACKAGE_MANAGER=pkg
+# LOWLEVEL_PACKAGE_MANAGER=pkgng
 
 # build pkgng plugin
 cd pkgng && make && make install


### PR DESCRIPTION
use ls and awk as non-GNU find doesn't have -printf

Tested on FreeBSD, should fix problems with busybox and other Un*x like
OS without GNU coreutils.

Signed-off-by: Petr Vorel <petr.vorel@gmail.com>