### PR TITLE
Give preference to etckeeper.conf over existing repository for defining $VCS

### DIFF
--- a/etckeeper
+++ b/etckeeper
@@ -109,14 +109,16 @@ fi
 cd "$ETCKEEPER_DIR"
 export ETCKEEPER_DIR
 
-if [ -d ".git" ]; then
-	VCS=git
-elif [ -d ".hg" ]; then
-	VCS=hg
-elif [ -d "_darcs" ]; then
-	VCS=darcs
-elif [ -d ".bzr" ]; then
-	VCS=bzr
+if [ -z "$VCS" ]; then
+	if [ -d ".git" ]; then
+		VCS=git
+	elif [ -d ".hg" ]; then
+		VCS=hg
+	elif [ -d "_darcs" ]; then
+		VCS=darcs
+	elif [ -d ".bzr" ]; then
+		VCS=bzr
+	fi
 fi
 
 if [ -z "$VCS" ]; then


### PR DESCRIPTION
I'm using etckeeper with hg and I will use git to manage some files under /etc apart from etckeeper for some reason.

However, after I initialize new git repository as /etc/.git, etckeeper starts to use git as $VCS contrary to definition in etckeeper.conf. So I think that definition in etckeeper.conf should be given priority over existing repository.

I would appreciate your consideration.
Thank you.
