### PR TITLE
Only show errors when pushing Git/Mercurial repos

### DIFF
--- a/commit.d/99push
+++ b/commit.d/99push
@@ -2,11 +2,11 @@
 if [ -n "$PUSH_REMOTE" ]; then
 	if [ "$VCS" = git ] && [ -d .git ]; then
 		for REMOTE in $PUSH_REMOTE; do
-			git push "$REMOTE" master || true
+			git push -q "$REMOTE" master || true
 		done
 	elif [ "$VCS" = hg ] && [ -d .hg ]; then
 		for REMOTE in $PUSH_REMOTE; do
-			hg push "$REMOTE" || true
+			hg push -q "$REMOTE" || true
 		done
 	else
 		echo "PUSH_REMOTE not yet supported for $VCS" >&2


### PR DESCRIPTION
When `etckeeper` is configured to automatically commit and push changes via a cronjob, the status output from the push command causes `cron` to send an alert email, even when no error occured:

> To git@git.example.com:etckeeper-sigma
   b601c6c..727559d  master -> master

This commit changes the default behaviour to `--quiet`, so the push command will only produce output when an error occurs.